### PR TITLE
Lower $plugin->requires to allow installation on 2.7

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,5 +28,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'atto_styles';
 $plugin->version = 2015111600;
 $plugin->release = '3.0 (Build: 2016010100)';
-$plugin->requires = 2015111600;
+$plugin->requires = 2014051200;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
As best as I can tell, there are no issues with running the code intended for 2.8+ on  2.7. In spite of this, the required version is set to 2.8.

Could we lower this to ease installation on the currently supported LTS release?
